### PR TITLE
Update DrakeCompanionClass.cs

### DIFF
--- a/ExpandedContent/Tweaks/Classes/DrakeClass/DrakeCompanionClass.cs
+++ b/ExpandedContent/Tweaks/Classes/DrakeClass/DrakeCompanionClass.cs
@@ -95,6 +95,8 @@ namespace ExpandedContent.Tweaks.Classes.DrakeClass {
                 bp.GiveFeaturesForPreviousLevels = true;
             });
             var DrakeCompanionClassProgression = Helpers.CreateBlueprint<BlueprintProgression>("DrakeCompanionClassProgression", bp => {
+                bp.SetName("");
+                bp.SetDescription("");
                 bp.m_AllowNonContextActions = false;
                 bp.IsClassFeature = true;
             });


### PR DESCRIPTION
Fix for the null appearing in the drake class progression view. It happens because the progression has no name or description, while it should have a blank string instead.