### PR TITLE
Heavens Capstone Tweak

### DIFF
--- a/ExpandedContent/Tweaks/Mysteries/HeavensMystery.cs
+++ b/ExpandedContent/Tweaks/Mysteries/HeavensMystery.cs
@@ -229,47 +229,17 @@ namespace ExpandedContent.Tweaks.Mysteries {
                     "on all {g|Encyclopedia:Saving_Throw}saving throws{/g} equal to your {g|Encyclopedia:Charisma}Charisma{/g} modifier. You become immune to fear effects, and automatically " +
                     "confirm all critical hits. Once per day, should you die, 1 {g|Encyclopedia:Combat_Round}round{/g} after dying you are reborn. Your body re-forms with all your equipment, " +
                     "and you return to life with maximum {g|Encyclopedia:HP}hit points{/g}.");
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveFortitude;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusCharisma
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Charisma;
+                    c.DerivativeStat = StatType.SaveFortitude;
                 });
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveReflex;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusCharisma
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Charisma;
+                    c.DerivativeStat = StatType.SaveWill;
                 });
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveWill;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusCharisma
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Charisma;
+                    c.DerivativeStat = StatType.SaveReflex;
                 });
                 bp.AddComponent<AddConditionImmunity>(c => {
                     c.Condition = UnitCondition.Frightened;

--- a/ExpandedContent/Tweaks/Spirits/HeavensSpirit.cs
+++ b/ExpandedContent/Tweaks/Spirits/HeavensSpirit.cs
@@ -474,47 +474,17 @@ namespace ExpandedContent.Tweaks.Spirits {
                     "on all {g|Encyclopedia:Saving_Throw}saving throws{/g} equal to your {g|Encyclopedia:Wisdom}Wisdom{/g} modifier. You become immune to fear effects, and automatically " +
                     "confirm all critical hits. Once per day, should you die, 1 {g|Encyclopedia:Combat_Round}round{/g} after dying you are reborn. Your body re-forms with all your equipment, " +
                     "and you return to life with maximum {g|Encyclopedia:HP}hit points{/g}.");
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveFortitude;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusWisdom
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Wisdom;
+                    c.DerivativeStat = StatType.SaveFortitude;
                 });
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveReflex;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusWisdom
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Wisdom;
+                    c.DerivativeStat = StatType.SaveWill;
                 });
-                bp.AddComponent<AddContextStatBonus>(c => {
-                    c.Descriptor = ModifierDescriptor.UntypedStackable;
-                    c.Stat = StatType.SaveWill;
-                    c.Multiplier = 1;
-                    c.Value = new ContextValue() {
-                        ValueType = ContextValueType.CasterProperty,
-                        Value = 0,
-                        ValueRank = AbilityRankType.Default,
-                        ValueShared = AbilitySharedValue.Damage,
-                        Property = UnitProperty.StatBonusWisdom
-                    };
-                    c.HasMinimal = false;
-                    c.Minimal = 0;
+                bp.AddComponent<DerivativeStatBonus>(c => {
+                    c.BaseStat = StatType.Wisdom;
+                    c.DerivativeStat = StatType.SaveReflex;
                 });
                 bp.AddComponent<AddConditionImmunity>(c => {
                     c.Condition = UnitCondition.Frightened;


### PR DESCRIPTION
I will lump both the final revelation and the manifestation of heavens spirit/mystery together. The capstone does not dynamically respond to changes in stats. I tested this using headbands. For example if charisma score is +4 and we equip bookworm's headband, the score becomes +3 but the capstone bonus to saves remains +4. It updates values after a reload or re-adding the feature through toybox. This holds true for animal buffs and possibly other stuff like cognatogen, ability damage etc.

Hopefully this small edit is serviceable.