### PR TITLE
cache regexes, remove needless localization load at LoadPackTOC

### DIFF
--- a/ExpandedContent/Localization/MultiLocalizationPack.cs
+++ b/ExpandedContent/Localization/MultiLocalizationPack.cs
@@ -191,7 +191,6 @@ namespace ExpandedContent.Localization {
     [HarmonyPatch(typeof(StartGameLoader), nameof(StartGameLoader.LoadPackTOC))]
     public static class StartGameLoader_LocalizationPatch {
         static void Postfix() {
-            ModSettings.ModLocalizationPack.ApplyToCurrentPack();
             ModSettings.SaveLocalization("LocalizationPack.Json", ModSettings.ModLocalizationPack);
         }
     }

--- a/ExpandedContent/Utilities/DescriptionTools.cs
+++ b/ExpandedContent/Utilities/DescriptionTools.cs
@@ -322,9 +322,14 @@ namespace ExpandedContent.Utilities {
             }
         }
 
+        internal static Dictionary<string, Regex> TagPatternsDictionary = new();
         private static string ApplyTags(this string str, string from, EncyclopediaEntry entry) {
-            var pattern = from.EnforceSolo().ExcludeTagged();
-            var matches = Regex.Matches(str, pattern, RegexOptions.IgnoreCase)
+            TagPatternsDictionary.TryGetValue(from, out var regex);
+            if (regex == null) {
+                regex = new Regex(from.EnforceSolo().ExcludeTagged(), RegexOptions.IgnoreCase);
+                TagPatternsDictionary.Add(from, regex);
+            }
+            var matches = regex.Matches(str)
                 .OfType<Match>()
                 .Select(m => m.Value)
                 .Distinct();
@@ -340,11 +345,15 @@ namespace ExpandedContent.Utilities {
             */
             return str;
         }
+
+        private static Regex HTMLRegex = new("<.*?>");
         public static string StripHTML(this string str) {
-            return Regex.Replace(str, "<.*?>", string.Empty);
+            return HTMLRegex.Replace(str, string.Empty);
         }
+
+        private static Regex EncyclopediaTagRegex = new("{.*?}");
         public static string StripEncyclopediaTags(this string str) {
-            return Regex.Replace(str, "{.*?}", string.Empty);
+            return EncyclopediaTagRegex.Replace(str, string.Empty);
         }
         private static string ExcludeTagged(this string str) {
             return $"{@"(?<!{g\|Encyclopedia:\w+}[^}]*)"}{str}{@"(?![^{]*{\/g})"}";


### PR DESCRIPTION
This substancially cuts down on time need to generate localization pack before adding it to game strings

Added load time of EC before on my machine: 17 seconds
With this change: 7 seconds.